### PR TITLE
drm: bridge: sn65dsi83: check return of of_drm_find_panel

### DIFF
--- a/drivers/gpu/drm/bridge/sn65dsi83/sn65dsi83_drv.c
+++ b/drivers/gpu/drm/bridge/sn65dsi83/sn65dsi83_drv.c
@@ -309,6 +309,14 @@ static int sn65dsi83_parse_dt(struct device_node *np,
 		of_node_put(endpoint);
 		if (remote) {
 			sn65dsi83->panel = of_drm_find_panel(remote);
+			if (IS_ERR(sn65dsi83->panel)) {
+				ret = PTR_ERR(sn65dsi83->panel);
+				if (ret == -ENODEV)
+					DRM_ERROR("panel not found, no device\n");
+				else
+					DRM_INFO("panel not found, deferring probe\n");
+				return ret;
+			}
 		} else {
 			DRM_ERROR("%s: output ep parent not found\n", __func__);
 			return -EPROBE_DEFER;


### PR DESCRIPTION
**of_drm_find_panel** can return pointer to error code on -ENODEV or -EPROBE_DEFER

call drm_panel_* functions in driver with panel pointed to ERR_PTR() can cause kernel panic